### PR TITLE
simulating all cards from one single suite

### DIFF
--- a/mvc-model.js
+++ b/mvc-model.js
@@ -4,6 +4,9 @@ var computerScore = 0;
 var suit = ['hearts','diamonds','clubs','spades'];
 var type = ['2','3','4','5','6','7','8','9','10','jack','queen','king','ace'];
 var value = [2,3,4,5,6,7,8,9,10,11,12,13,14];
+var suitTaken = [];
+var typeTaken = [];
+var rounds = 0;
 
 var cardTypeCount = type.length;
 var randCache;
@@ -14,7 +17,27 @@ function rand(n) {
 }
 
 function deal() {
-  this.suit = suit[rand(4)];
-  this.type = type[rand(cardTypeCount)];
-  this.value = value[randCache];
+  do {
+    this.suit = suit[rand(4)];
+    this.type = type[rand(cardTypeCount)];
+    this.value = value[randCache];
+  } while (cardTaken(this.suit, this.type));
+  suitTaken.push(this.suit);
+  typeTaken.push(this.type);
+  rounds += 1;
+}
+
+function clearTakenSuite(){
+  suitTaken = [];
+  typeTaken = [];
+  rounds = 0;
+}
+
+function cardTaken(suiteCard, typeCard){
+  for (let i = 0; i < rounds; i++) {
+    if(suiteCard == suitTaken[i] && typeCard == typeTaken[i] ){
+      return 1;
+    }
+  } 
+  return 0;
 }

--- a/mvc-view.js
+++ b/mvc-view.js
@@ -55,6 +55,7 @@ function displayResult() {
   } else { 
     $('#result').append('<h2>'+winner+' the winner this time!</h2><br />'); 
   }
+  clearTakenSuite();
 }
 
 function updateScore(player, value) {


### PR DESCRIPTION

### **This PR solves issue Single suite #15**
**Issue** : The cards in hand were duplicates (sometimes) but in a real game there is no possibility of such a case
**Solution** : Make an array to store the cards which are already taken and select the next card only if the card isnt present in the taken deck
**Downsides** :  Takes a bit more storage (unnoticeable on my PC) and a repeats few steps to make it fair.

**Proof of working** (console message statement removed in final version)
-
![Screenshot 2022-10-25 122417](https://user-images.githubusercontent.com/93852415/197707866-8383847e-8f31-48b3-a295-8d4b4e332fed.png)

Hope this solves this Issue,
Looking forward to make it a better project than it already is.
## Thank You for allowing me to work on this